### PR TITLE
Okno ustawień

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -79,6 +79,7 @@ main{
   box-shadow: inset 0px 0px 10px 5px rgba(255,0,10,0.5), 0px 2px 50px 10px rgba(255,0,10,0.5);
   transition: border-color 0.25s;
   border-radius: 8px;
+  position:relative;
 }
 footer{
   margin-top: 20px;
@@ -126,4 +127,5 @@ footer{
   background-color: rgb(31, 31, 31);
   border-radius: 8px;
   box-shadow: inset 0px 0px 5px 5px rgba(255,0,10,0.5), 0px 2px 20px 5px rgba(255,0,10,0.5);
+  position:absolute;
 }

--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -46,6 +46,6 @@ function changeTheme(){
         element.addEventListener("mouseout", () => { element.style.animation = "" });
       });
     }
-};
+}
 
 export default changeTheme;


### PR DESCRIPTION
Okno ustawień przesuwało się na prawo po włączeniu jednej z gier. Od teraz włączone okno znajduję się nad oknem gry